### PR TITLE
chore: prepare release v3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 -
 
+## [3.0.1] - 2026-07-12
+
+### Fixed
+- **Munich (MVV) departures** - The MVV API now rejects a missing or
+  non-base64 `lines` parameter with HTTP 400, which stopped all Munich
+  departures from loading. The request now sends a base64-encoded empty
+  filter (`[]`) so all lines are returned again.
+- **Würzburg departures via nginx proxy** - The EFA upstream
+  (`whitelabel.bahnland-bayern.de`) is behind a load balancer that routes
+  TLS connections by SNI. Without `proxy_ssl_server_name on`, nginx omitted
+  SNI and requests landed on a default backend returning `421 Misdirected
+  Request`. Enabled `proxy_ssl_server_name` on both API proxy locations.
+- Removed a duplicate `@types/node` key in `package.json` that produced a
+  build-time warning.
+- **Release archive script on Windows** - `scripts/create-archives.js`
+  compared `import.meta.url` against a hand-built `file://` string, which
+  never matched on Windows (backslashes / drive letter), so `pnpm release`
+  silently produced no archives. Now uses `pathToFileURL` for a correct
+  cross-platform comparison.
+
 ## [3.0.0] - 2025-12-29
 
 ### Added

--- a/nginx.conf
+++ b/nginx.conf
@@ -83,6 +83,10 @@ http {
         location /wuerzburg-api/ {
             rewrite ^/wuerzburg-api/(.*)$ /$1 break;
             proxy_pass https://whitelabel.bahnland-bayern.de/;
+            # The upstream is behind a load balancer that routes TLS
+            # connections by SNI. Without this, nginx omits SNI and the
+            # request lands on a default backend that returns 421.
+            proxy_ssl_server_name on;
             proxy_set_header Host whitelabel.bahnland-bayern.de;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -93,6 +97,7 @@ http {
         location /mvv-api/ {
             rewrite ^/mvv-api/(.*)$ /$1 break;
             proxy_pass https://www.mvv-muenchen.de/;
+            proxy_ssl_server_name on;
             proxy_set_header Host www.mvv-muenchen.de;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "departure-monitor",
   "private": true,
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Monitor for departure public transportation",
   "homepage": "https://github.com/ironpinguin/departure-monitor",
   "author": {
@@ -63,7 +63,6 @@
     "vite": "^6.4.1",
     "wait-on": "^7.2.0",
     "form-data": "^4.0.4",
-    "@types/node": "^22.0.0",
     "vitest": "^3.2.4"
   },
   "pnpm": {

--- a/scripts/create-archives.js
+++ b/scripts/create-archives.js
@@ -3,7 +3,7 @@
 import fs from 'fs/promises';
 import { createWriteStream } from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import archiver from 'archiver';
 import * as tar from 'tar';
 import chalk from 'chalk';
@@ -217,7 +217,9 @@ async function main() {
 }
 
 // Script ausführen wenn direkt aufgerufen
-if (import.meta.url === `file://${process.argv[1]}`) {
+// pathToFileURL sorgt für korrekte file://-URLs auf allen Plattformen
+// (unter Windows enthält process.argv[1] Backslashes und einen Laufwerksbuchstaben)
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   main().catch(error => {
     console.error(chalk.red('Unerwarteter Fehler:'), error);
     process.exit(1);

--- a/src/api/muenchenApi.ts
+++ b/src/api/muenchenApi.ts
@@ -1,9 +1,14 @@
 import type { Departure, MUCResponse, MucDeparture } from '../models/index';
 
+// The MVV API expects the `lines` parameter to be a base64-encoded JSON array
+// used to filter by specific lines. An empty array (base64 "W10=") means "no
+// filter" and returns all lines. The API rejects a missing or non-base64 value.
+const LINES_FILTER_ALL = 'W10='; // base64 of "[]"
+
 export async function fetchMuenchenDepartures(stopId: string): Promise<Departure[]> {
   const timestamp = Math.floor(Date.now() / 1000);
   const baseUrl = 'https://www.mvv-muenchen.de/';
-  const url = `${baseUrl}/?eID=departuresFinder&action=get_departures&stop_id=${stopId}&requested_timestamp=${timestamp}&lines`;
+  const url = `${baseUrl}/?eID=departuresFinder&action=get_departures&stop_id=${stopId}&requested_timestamp=${timestamp}&lines=${LINES_FILTER_ALL}`;
 
   const response = await fetch(url);
   if (!response.ok) {


### PR DESCRIPTION
## Summary

Patch release **v3.0.1** — restores real-time departure loading, which had
stopped working for both supported cities.

## Fixes

- **Munich (MVV)** — The MVV API now rejects a missing or non-base64
  `lines` query parameter with HTTP 400, so no departures loaded. The
  request now sends a base64-encoded empty filter (`[]` → `W10=`), which
  returns all lines again.
- **Würzburg (nginx proxy)** — The EFA upstream
  (`whitelabel.bahnland-bayern.de`) sits behind a load balancer that routes
  TLS connections by SNI. Without `proxy_ssl_server_name on`, nginx omitted
  SNI and requests hit a default backend returning `421 Misdirected
  Request`. Enabled `proxy_ssl_server_name` on both API proxy locations.
  (Note: the production host nginx needs the same one-line change; already
  applied there.)
- **Build/tooling** — Removed a duplicate `@types/node` key in
  `package.json` (build warning) and fixed `scripts/create-archives.js` so
  `pnpm release` actually produces archives on Windows (`pathToFileURL`).

## Verification

- Both APIs tested directly and via the dev proxy — 200 with departure data.
- App verified in a real browser: both Würzburg stops and a Munich stop now
  render departures.
- `pnpm lint` and `pnpm build` clean (no duplicate-key warning).
- `pnpm release` produces `departure-monitor-v3.0.1.{zip,tar.gz}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
