### PR TITLE
chore: prepare release v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 -
 
+## [3.1.0] - 2026-07-12
+
+### Added
+- **Stop search in the add/edit dialog** - Users can now search for stops by
+  name directly in the add/edit stop dialog for both Munich (MVV) and Würzburg,
+  instead of relying only on predefined stops.
+
+### Removed
+- Dropped the unused `express` and `http-proxy-middleware` runtime dependencies.
+
+### Changed
+- CI maintenance: pinned GitHub Actions and the Claude Code action model,
+  added Dependabot for the github-actions ecosystem, and bumped several
+  action and dev-dependency versions.
+
 ## [3.0.1] - 2026-07-12
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "departure-monitor",
   "private": true,
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Monitor for departure public transportation",
   "homepage": "https://github.com/ironpinguin/departure-monitor",
   "author": {


### PR DESCRIPTION
## Release v3.1.0

Prepares the v3.1.0 release.

### Changes
- Bump `package.json` version `3.0.1` → `3.1.0`
- Update `CHANGELOG.md` with the `[3.1.0]` section

### Highlights since v3.0.1
- **Added:** Stop search in the add/edit dialog for Munich (MVV) and Würzburg (#38)
- **Removed:** Unused `express` / `http-proxy-middleware` deps (#39)
- **Changed:** CI action/model pins fixed, Dependabot added, dependency bumps

After merge: tag `v3.1.0` on main and publish the GitHub Release; `release.yml` builds the Docker image and archives automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)